### PR TITLE
Remove unused values

### DIFF
--- a/helm-azimuth/values.yaml
+++ b/helm-azimuth/values.yaml
@@ -10,5 +10,5 @@ zenithClient:
 # RAGflow values
 ragflow:
   env:
-    RAGFLOW_IMAGE: infiniflow/ragflow:v0.19.0
+    RAGFLOW_IMAGE: infiniflow/ragflow:v0.19.1
     DOC_ENGINE: infinity

--- a/helm-azimuth/values.yaml
+++ b/helm-azimuth/values.yaml
@@ -12,6 +12,3 @@ ragflow:
   env:
     RAGFLOW_IMAGE: infiniflow/ragflow:v0.19.0
     DOC_ENGINE: infinity
-  api:
-    service:
-      enabled: true


### PR DESCRIPTION
Nesting was incorrect and upstream now defaults to enabling API service anyway so we can remove this in Azimuth chart.