### PR TITLE
Switch to OpenSearch as default vector DB

### DIFF
--- a/helm-azimuth/values.yaml
+++ b/helm-azimuth/values.yaml
@@ -11,4 +11,4 @@ zenithClient:
 ragflow:
   env:
     RAGFLOW_IMAGE: infiniflow/ragflow:v0.19.1
-    DOC_ENGINE: infinity
+    DOC_ENGINE: opensearch

--- a/helm/templates/opensearch.yaml
+++ b/helm/templates/opensearch.yaml
@@ -85,13 +85,14 @@ spec:
           runAsUser: 1000
           allowPrivilegeEscalation: false
         livenessProbe:
-          httpGet:
-            path: /
-            port: 9201
+          exec:
+            command:
+              - sh
+              - -c
+              - curl -u admin:$OPENSEARCH_PASSWORD localhost:9201
           initialDelaySeconds: 30
           periodSeconds: 10
-          timeoutSeconds: 10
-          failureThreshold: 120
+          failureThreshold: 6
       volumes:
         - name: opensearch-data
           persistentVolumeClaim:

--- a/helm/templates/redis.yaml
+++ b/helm/templates/redis.yaml
@@ -68,7 +68,7 @@ spec:
     - metadata:
         name: redis-data
         labels:
-          {{- include "ragflow.labels" . | nindent 10 }}
+          {{- include "ragflow.selectorLabels" . | nindent 10 }}
           app.kubernetes.io/component: redis
       spec:
         accessModes:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -192,8 +192,6 @@ redis:
     resources:
   service:
     type: ClusterIP
-  persistence:
-    enabled: false
 
 
 # This block is for setting up web service ingress. For more information, see:


### PR DESCRIPTION
Also fixes duplicate persistence key likely introduced as part of previous upstream merge conflict and cherry-picks some other upstream Helm chart fixes.