### PR TITLE
Revert to Elasticsearch as default vector DB

### DIFF
--- a/helm-azimuth/values.yaml
+++ b/helm-azimuth/values.yaml
@@ -11,7 +11,7 @@ zenithClient:
 ragflow:
   env:
     RAGFLOW_IMAGE: infiniflow/ragflow:v0.19.1
-    DOC_ENGINE: opensearch
+    DOC_ENGINE: elasticsearch
 
   redis:
     persistence:


### PR DESCRIPTION
Infinity DB was found to exhibit stability issues and occasional data loss in testing and OpenSearch support is still too new and not as well tested / supported upstream as elasticsearch backend.