### PR TITLE
Update actions to org-wide pins

### DIFF
--- a/.github/workflows/helm-chart-publish.yml
+++ b/.github/workflows/helm-chart-publish.yml
@@ -17,10 +17,10 @@ jobs:
 
       - name: Get SemVer version for current commit
         id: semver
-        uses: azimuth-cloud/github-actions/semver@master
+        uses: azimuth-cloud/github-actions/semver@8771cb1c1db134e99becf314f07db6a84b8d7fbf
 
       - name: Publish Helm charts
-        uses: azimuth-cloud/github-actions/helm-publish@master
+        uses: azimuth-cloud/github-actions/helm-publish@8771cb1c1db134e99becf314f07db6a84b8d7fbf
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ steps.semver.outputs.version }}

--- a/.github/workflows/helm-chart-publish.yml
+++ b/.github/workflows/helm-chart-publish.yml
@@ -7,6 +7,8 @@ jobs:
   build_push_chart:
     name: Build and push Helm chart
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Updates GH actions to versions required by the organisation-wide whitelist: https://github.com/stackhpc/github-actions-list/blob/main/stackhpc.pinned.txt
