### PR TITLE
helm: set default cpu/memory configuration for each ragflow component

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -74,6 +74,10 @@ env:
   # The number of text chunks processed in a single batch during embedding vectorization.
   EMBEDDING_BATCH_SIZE: 16
 
+  # XMX and XMS should be lower that the limits (50-75%)
+  # Some data are stored outside of the heap.
+  ES_JAVA_OPTS: "-Xms12Gi -Xmx12Gi"
+
 ragflow:
   image:
     repository: infiniflow/ragflow
@@ -160,6 +164,10 @@ elasticsearch:
       requests:
         cpu: "4"
         memory: "16Gi"
+      limits:
+        cpu: "4"
+        memory: "16Gi"
+
   service:
     type: ClusterIP
 
@@ -187,6 +195,9 @@ opensearch:
       requests:
         cpu: "4"
         memory: "16Gi"
+      limits:
+        cpu: "4"
+        memory: "16Gi"
   service:
     type: ClusterIP
 
@@ -203,6 +214,12 @@ minio:
   deployment:
     strategy:
     resources:
+      requests:
+        cpu: "1"
+        memory: "512Mi"
+      limits:
+        cpu: "1"
+        memory: "512Mi"
   service:
     type: ClusterIP
 
@@ -219,6 +236,12 @@ mysql:
   deployment:
     strategy:
     resources:
+      requests:
+        cpu: "1"
+        memory: "512Mi"
+      limits:
+        cpu: "1"
+        memory: "512Mi"
   service:
     type: ClusterIP
 
@@ -242,6 +265,11 @@ redis:
   deployment:
     strategy:
     resources:
+      requests:
+        cpu: "1"
+        memory: 32Mi
+      limits:
+        memory: 32Mi
   service:
     type: ClusterIP
 


### PR DESCRIPTION
### What problem does this PR solve?

The default deployment does not set `requests` / `limits` resources attributes to each pod. As a consequence, noisy neighbor and OOM effects can happen.

This PR sets default resources to make sure that the scheduler can avoid overloading a node. 

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [x] Other (please describe): better operations.
