### PR TITLE
Adding resources limits on rag flow and infinity deployments

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -110,6 +110,12 @@ ragflow:
   deployment:
     strategy:
     resources:
+      requests:
+        cpu: "4"
+        memory: "6Gi"
+      limits:
+        cpu: "4"
+        memory: "6Gi"
   service:
     # Use LoadBalancer to expose the web interface externally
     type: ClusterIP
@@ -137,6 +143,12 @@ infinity:
   deployment:
     strategy:
     resources:
+      requests:
+        cpu: "4"
+        memory: "6Gi"
+      limits:
+        cpu: "4"
+        memory: "6Gi"
   service:
     type: ClusterIP
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -76,7 +76,7 @@ env:
 
   # XMX and XMS should be lower that the limits (50-75%)
   # Some data are stored outside of the heap.
-  ES_JAVA_OPTS: "-Xms12Gi -Xmx12Gi"
+  ES_JAVA_OPTS: "-Xms12g -Xmx12g"
 
 ragflow:
   image:


### PR DESCRIPTION
### What problem does this PR solve?

Some components still lacked resources `requests` and `limits`.
The `ES_JAVA_OPTS` set a JVM memory limit with a bad unit ("Gi" instead of "g"). This prevented the `StatefulSet` to start.

### Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update
- [ ] Refactoring
- [x] Performance Improvement
- [x] Other (please describe): operations / capacity planning.
